### PR TITLE
apt_repo_keyed module

### DIFF
--- a/roles/workstation/library/apt_repo_keyed.py
+++ b/roles/workstation/library/apt_repo_keyed.py
@@ -38,16 +38,16 @@ def run_module():
         module.fail_json('Error retrieving gpg key from provided URL')
 
     gpg_raw = gpg_response.read().decode('utf8')
-    rc, gpg_converted, _ = module.run_command('gpg --yes --dearmor', data=gpg_raw)
+    rc, gpg_converted, _ = module.run_command('gpg --yes --dearmor', data=gpg_raw, encoding=None)
     if rc != 0:
         module.fail_json(**result)
     
-    gpg_converted = gpg_converted.encode('utf-8')
+    gpg_converted = gpg_converted
     
-    gpg_sha_expected = sha256(gpg_converted)
+    gpg_sha_expected = sha256(gpg_converted).hexdigest()
     gpg_sha_actual = module.sha256(gpg_key_location)
 
-    if gpg_sha_expected.hexdigest() != gpg_sha_actual:
+    if gpg_sha_expected != gpg_sha_actual:
         result['changed'] = True
         if not module.check_mode:
             with open(gpg_key_location, 'wb') as gpg_key_file:
@@ -59,21 +59,15 @@ def run_module():
         distro=module.params['distro'],
         name=module.params['repo_name'],
     ).encode('utf8')
-    apt_sha_expected = sha256(apt_line)
+    apt_sha_expected = sha256(apt_line).hexdigest()
     apt_sha_actual = module.sha256(apt_list_location)
-    if apt_sha_expected.hexdigest() != apt_sha_actual:
+    if apt_sha_expected != apt_sha_actual:
         result['changed'] = True
         if not module.check_mode:
             with open(apt_list_location, 'wb') as apt_list_file:
                 apt_list_file.write(apt_line)
     
     module.exit_json(**result)
-
-
-
-
-
-
 
 def main():
     run_module()


### PR DESCRIPTION
Creating a module that sets up an apt repo with it's own gpg key (ala the `signed_by` directive).

Base Features:
- [x] Download GPG key via specified URL
- [ ] Ensure TLS validation on GPG key pulls
- [ ] Reject gpg_url's without https
- [x] customize the distro put in the apt list
- [x] Specify repo url
- [x] Specify repo name (main, security, src, etc)
- [ ] Allow gpg key to be specified via text
- [ ] Cache update option

Make check mode more productive:
- [ ] Validate repo url
- [ ] Validate gpg url
- [ ] Validate gpg text
- [ ] Check that GPG (and other dependancies) exist on the machine

Resiliency stuff:
- [ ] Make apt list file change atomic
- [ ] Make gpg key file change atomic
- [ ] See if gpg de-armoring can be done in pure python
- [ ] Real tests